### PR TITLE
Chunked content. Comment requested

### DIFF
--- a/data/samizdat/templates/lazy_frontpage_index_1.rhtml
+++ b/data/samizdat/templates/lazy_frontpage_index_1.rhtml
@@ -1,0 +1,18 @@
+<% unless @language_list.empty? %>
+<div id="languages"><%= @language_list %></div>
+<% end %>
+
+<% unless @header.empty? %>
+<div id="front-header"><%= @header %></div>
+<% end %>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= _('Top Tags') %></th>
+      <th><%= _('Features') %></th>
+      <th><%= _('Recent Updates') %></th>
+    </tr>
+  </thead>
+  <tr>
+    <td class="tags">

--- a/data/samizdat/templates/lazy_frontpage_index_2.rhtml
+++ b/data/samizdat/templates/lazy_frontpage_index_2.rhtml
@@ -1,0 +1,3 @@
+      <div class="foot"><div class="nav"><a href="tags"><%= _('more') %></a></div></div>
+    </td>
+    <td class="features" rowspan="3">

--- a/data/samizdat/templates/lazy_frontpage_index_3.rhtml
+++ b/data/samizdat/templates/lazy_frontpage_index_3.rhtml
@@ -1,0 +1,3 @@
+      <div class="foot"><%= nav_rss(@feeds[ _('Features') ]) %></div>
+    </td>
+    <td class="updates" rowspan="3">

--- a/data/samizdat/templates/lazy_frontpage_index_4.rhtml
+++ b/data/samizdat/templates/lazy_frontpage_index_4.rhtml
@@ -1,0 +1,15 @@
+      <div class="foot"><%= nav_rss(@feeds[ _('Recent Updates') ]) %></div>
+    </td>
+  </tr>
+  <tr><td class="links-head"><%= _('Links') %></td></tr>
+  <tr><td class="links">
+    <p><a href="query/run?q=<%= @all_replies_query %>"><%= _('All Replies') %></a></p>
+    <p><a href="moderation"><%= _('Moderation Log') %></a></p>
+    <%= @more_links %>
+    <%= @imported_feeds %>
+  </td></tr>
+</table>
+
+<% unless @footer.empty? %>
+<div id="front-footer"><%= @footer %></div>
+<% end %>

--- a/data/samizdat/templates/lazy_page_layout_begin.rhtml
+++ b/data/samizdat/templates/lazy_page_layout_begin.rhtml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= @request.language %>" lang="<%= @request.language %>">
+<head>
+  <title><%= @title %></title>
+  <base href="<%= @request.base %>" />
+  <meta name="generator" content="Samizdat <%= SAMIZDAT_VERSION %>" />
+
+  <link rel="stylesheet" type="text/css" href="css/<%= @request.style %>.css" media="screen" />
+<% @request.alt_styles.each do |alt| %>
+  <link rel="alternate stylesheet" type="text/css" title="<%= alt %>" href="css/<%= alt %>.css" media="screen" />
+<% end %>
+
+<% @feeds.each do |title, link| %>
+  <link rel="alternate" type="application/rss+xml" title="<%= title %>" href="<%= @request.base + link %>" />
+<% end %>
+<% @links.each do |rel, href| %>
+  <link rel="<%= rel %>" href="<%= href %>" />
+<% end %>
+
+<% @js.each do |js| %>
+  <script type="text/javascript" src="js/<%= js %>.js"></script>
+<% end %>
+</head>
+
+<body>
+<div><a href="#main" class="hidden">Skip navigation</a></div>
+<div id="head">
+  <div id="head-left"><a href="<%= @request.base %>" title="<%= logo_link_title %>"><%= config['site']['logo'] %></a></div>
+  <div id="head-right"><a href="message/publish"><%= _('Publish') %></a>
+    :: <a href="query"><%= _('Search') %></a></div>
+</div>
+<div id="subhead">
+  <div id="subhead-right">
+<% unless @member.guest? %>
+    <%= member_link(@member) %>:
+    <a href="member/profile" title="<%= _('View and edit your profile') %>"><%= _('Profile') %></a>,
+    <a href="member/account" title="<%= _('Change account parameters (email and password)') %>"><%= _('Account') %></a>,
+<% end %>
+    <a href="member/settings" title="<%= _('Change user interface settings') %>"><%= _('Settings') %></a>,
+<% if @session.member %>
+    <a href="member/logout"><%= _('Log out') %></a>
+<% else %>
+    <a href="member/login"><%= _('Log in') %></a>
+<% end %>
+  </div>
+</div>
+
+<div id="main">
+

--- a/data/samizdat/templates/lazy_page_layout_end.rhtml
+++ b/data/samizdat/templates/lazy_page_layout_end.rhtml
@@ -1,0 +1,13 @@
+
+<div id="foot">
+Powered by <a href="http://www.fsf.org/">Free Software</a>, including
+<a href="http://www.ruby-lang.org/">Ruby</a> programming language,
+<a href="http://www.postgresql.org/">PostgreSQL</a> database.
+<a href="http://samizdat.nongnu.org/">Samizdat</a> engine is free
+software; you can distribute/modify it under the terms of the GNU
+<a href="http://www.gnu.org/licenses/gpl.txt">General Public License</a>
+version 3 or later.</div>
+
+</div>
+</body>
+</html>

--- a/lib/samizdat/controllers/frontpage_controller.rb
+++ b/lib/samizdat/controllers/frontpage_controller.rb
@@ -46,19 +46,20 @@ class FrontpageController < Controller
     @template = 'frontpage_index.rhtml'
     @lazy_content << 'lazy_page_layout_begin.rhtml'
     @lazy_content << 'lazy_frontpage_index_1.rhtml'
-    @lazy_content << lambda { tag_cloud }
+    @lazy_content << lambda {|_| tag_cloud }
     @lazy_content << 'lazy_frontpage_index_2.rhtml'
-    @lazy_content << lambda { FeaturesList.new(@request) }
+    @lazy_content << lambda {|_| FeaturesList.new(@request) }
     @lazy_content << 'lazy_frontpage_index_3.rhtml'
-    @lazy_content << lambda { UpdatesList.new(@request) }
+    @lazy_content << lambda {|_| UpdatesList.new(@request) }
     @lazy_content << 'lazy_frontpage_index_4.rhtml'
     @lazy_content << 'lazy_page_layout_end.rhtml'
   end
 
   def render
-     out = LazyContent.new
+
+     out = LazyContent.new(@request)
      @lazy_content.each do |x|
-       out << x.kind_of?(Proc) ? x : render_template(x)
+       out.push(x.kind_of?(Proc) ? x : render_template(x))
      end
      out
   end

--- a/lib/samizdat/controllers/frontpage_controller.rb
+++ b/lib/samizdat/controllers/frontpage_controller.rb
@@ -20,6 +20,8 @@ class FrontpageController < Controller
       _('Features') => 'frontpage/rss',
       _('Recent Updates') => 'frontpage/rss?feed=updates'
     )
+
+    @lazy_content = []
   end
 
   def index
@@ -42,6 +44,23 @@ class FrontpageController < Controller
     @footer = static_text('footer')
 
     @template = 'frontpage_index.rhtml'
+    @lazy_content << 'lazy_page_layout_begin.rhtml'
+    @lazy_content << 'lazy_frontpage_index_1.rhtml'
+    @lazy_content << lambda { tag_cloud }
+    @lazy_content << 'lazy_frontpage_index_2.rhtml'
+    @lazy_content << lambda { FeaturesList.new(@request) }
+    @lazy_content << 'lazy_frontpage_index_3.rhtml'
+    @lazy_content << lambda { UpdatesList.new(@request) }
+    @lazy_content << 'lazy_frontpage_index_4.rhtml'
+    @lazy_content << 'lazy_page_layout_end.rhtml'
+  end
+
+  def render
+     out = LazyContent.new
+     @lazy_content.each do |x|
+       out << x.kind_of?(Proc) ? x : render_template(x)
+     end
+     out
   end
 
   def features

--- a/lib/samizdat/engine.rb
+++ b/lib/samizdat/engine.rb
@@ -60,3 +60,5 @@ require 'samizdat/components/resource'
 require 'samizdat/components/list'
 
 require 'samizdat/engine/plugins'
+
+require 'samizdat/engine/lazycontent'

--- a/lib/samizdat/engine/lazycontent.rb
+++ b/lib/samizdat/engine/lazycontent.rb
@@ -1,0 +1,51 @@
+# Samizdat time handling
+#
+#   Copyright (c) 2002-2011  Dmitry Borodaenko <angdraug@debian.org>
+#
+#   This program is free software.
+#   You can distribute/modify this program under the terms of
+#   the GNU General Public License version 3 or later.
+#
+# vim: et sw=2 sts=2 ts=8 tw=0
+
+class LazyContent
+  include Enumerable
+
+  def initialize request
+    @request = request
+    @content = []
+  end
+
+  def each
+    @content.each_with_index {|a,i| yield(@content[i]=force_val(a)) }
+  end
+
+  def to_s
+    force.to_s
+  end
+
+  def join separator=$,
+    force.join(separator)
+  end
+
+  def force
+    map{|x| x}
+  end
+
+  def method_missing method, *args, &block
+    @content.__send__(method, *args, &block)
+    self
+  end
+
+private
+  def force_val a
+    a.kind_of?(Proc) ? a.call(@request) : a
+  end
+end
+
+class Array
+  alias old_plus +
+  def + obj
+    obj.kind_of?(LazyContent) ? obj + self : old_plus(obj)
+  end
+end

--- a/lib/samizdat/engine/lazycontent.rb
+++ b/lib/samizdat/engine/lazycontent.rb
@@ -17,7 +17,7 @@ class LazyContent
   end
 
   def each
-    @content.each_with_index {|a,i| yield(@content[i]=force_val(a)) }
+    @content.each_with_index {|a,i| yield(@content[i]=force_val(a).to_s) }
   end
 
   def to_s

--- a/lib/samizdat/engine/request.rb
+++ b/lib/samizdat/engine/request.rb
@@ -380,6 +380,8 @@ class Request
 
     body = controller.render
     if body.kind_of?(LazyContent)
+      @headers['Content-Type'] ||= 'text/html'
+      @headers['Content-Type'] << '; charset=utf-8'
       return [ @status, @headers, body ]
     else
     body = compress(body) unless 302 == @status

--- a/lib/samizdat/engine/request.rb
+++ b/lib/samizdat/engine/request.rb
@@ -378,7 +378,11 @@ class Request
       set_cookie('notice', @notice)
     end
 
-    body = compress(controller.render) unless 302 == @status
+    body = controller.render
+    if body.kind_of?(LazyContent)
+      return [ @status, @headers, body ]
+    else
+    body = compress(body) unless 302 == @status
 
     unless 304 == @status
       @headers['Content-Type'] ||= 'text/html'
@@ -391,6 +395,7 @@ class Request
       return [ @status, @headers, [body] ]
     else
       return [ @status, @headers, [] ]
+    end
     end
   end
 


### PR DESCRIPTION
This is a quick and dirty patch, it's enables usage of "chunked" output of front page. While it doesn't speed up front page rendering it speeds up its delivery to user because it's rendered and sent to user chunk by chunk. And it sh'ld protect against "request timeout" error.

I'm not sure that it will work under thin or another EM-based server, but it works under good old forking servers like unicorn.

What do you think about such way of speed up?
