### PR TITLE
Remove hard dependence on html/textile source formats.

### DIFF
--- a/lib/samizdat/engine.rb
+++ b/lib/samizdat/engine.rb
@@ -49,6 +49,8 @@ require 'samizdat/engine/view'
 require 'samizdat/engine/controller'
 require 'samizdat/engine/dispatcher'
 
+require 'samizdat/engine/inline'
+
 # samizdat application
 require 'samizdat/models/member'
 require 'samizdat/models/message'

--- a/lib/samizdat/engine/inline.rb
+++ b/lib/samizdat/engine/inline.rb
@@ -1,0 +1,15 @@
+# Samizdat inline format cache handling
+#
+#   Copyright (c) 2002-2011  Dmitry Borodaenko <angdraug@debian.org>
+#
+#   This program is free software.
+#   You can distribute/modify this program under the terms of
+#   the GNU General Public License version 3 or later.
+#
+# vim: et sw=2 sts=2 ts=8 tw=0
+
+# inline formats that need a link to view source
+#
+class InlineFormat < Hash
+  include Singleton
+end

--- a/lib/samizdat/helpers/message_helper.rb
+++ b/lib/samizdat/helpers/message_helper.rb
@@ -30,13 +30,6 @@ module MessageHelper
     }.join(', ')
   end
 
-  # inline formats that need a link to view source
-  #
-  SOURCE_FORMAT = {
-    'text/textile' => 'textile',
-    'text/html' => 'html'
-  }
-
   # render _message_ info line (except tags)
   #
   def message_info(message, mode)
@@ -64,7 +57,7 @@ module MessageHelper
       if message.id and message.nversions.to_i > 0
         history = %{<a href="history/#{message.id}">} + _('history') + '</a>'
       end
-      if message.id and format = SOURCE_FORMAT[message.content.format]
+      if message.id and format = InlineFormat.instance[message.content.format]
         source = %{<a href="message/#{message.id}/source" title="} +
           _('view source') + %{">#{format}</a>}
       end

--- a/lib/samizdat/plugins/content_inline.rb
+++ b/lib/samizdat/plugins/content_inline.rb
@@ -51,6 +51,11 @@ class ContentInlinePlugin < Plugin
     end
   end
 
+  def self.register_inline_format(full, short)
+    register_as short
+    InlineFormat.instance[full] = short
+  end
+
   private
 
   CUT_MARK_DEFAULT = '$$$'

--- a/lib/samizdat/plugins/html.rb
+++ b/lib/samizdat/plugins/html.rb
@@ -12,7 +12,7 @@ require 'samizdat'
 require 'samizdat/plugins/content_inline'
 
 class HtmlPlugin < ContentInlinePlugin
-  register_as 'html'
+  register_inline_format 'text/html', 'html'
 
   def match?(format)
     'text/html' == format

--- a/lib/samizdat/plugins/textile.rb
+++ b/lib/samizdat/plugins/textile.rb
@@ -34,7 +34,7 @@ rescue LoadError
 end
 
 class TextilePlugin < ContentInlinePlugin
-  register_as 'textile'
+  register_inline_format 'text/textile', 'textile'
 
   def match?(format)
     'text/textile' == format


### PR DESCRIPTION
This code was a part of pull request #1 but now it refactored not to have dangerous use of class variables. The hash of available source formats is filled during plugin loading.
